### PR TITLE
Buildah used by podman does not support the --link switch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,14 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
 # Install node modules
-COPY --link package-lock.json package.json ./
-COPY --link ./scripts ./scripts
-COPY --link ./views ./views
+COPY  package-lock.json package.json ./
+COPY  ./scripts ./scripts
+COPY  ./views ./views
 
 RUN npm ci
 
 # Copy application code
-COPY --link . .
+COPY  . .
 
 # Final stage for app image
 FROM base


### PR DESCRIPTION
This is the changes required to build in podman. They do have some impact on your existing build, so an alternative approaches are:

1.  provide  a `Containerfile` instead. But then we wouild nned to keep `Dockerfile` and `Containerfile` in sync.
2. Create GH action to build and publish the image in ghcr like intercode

